### PR TITLE
Bitbucket api call fails when no access

### DIFF
--- a/vendor/github.com/Bowery/prompt/ansi_unix.go
+++ b/vendor/github.com/Bowery/prompt/ansi_unix.go
@@ -1,4 +1,4 @@
-// +build linux darwin freebsd openbsd netbsd dragonfly
+// +build linux darwin freebsd openbsd netbsd dragonfly solaris
 
 // Copyright 2013-2015 Bowery, Inc.
 

--- a/vendor/github.com/Bowery/prompt/buffer_unix.go
+++ b/vendor/github.com/Bowery/prompt/buffer_unix.go
@@ -1,4 +1,4 @@
-// +build linux darwin freebsd openbsd netbsd dragonfly 
+// +build linux darwin freebsd openbsd netbsd dragonfly solaris
 
 // Copyright 2013-2015 Bowery, Inc.
 

--- a/vendor/github.com/Bowery/prompt/keys_unix.go
+++ b/vendor/github.com/Bowery/prompt/keys_unix.go
@@ -1,4 +1,4 @@
-// +build linux darwin freebsd openbsd netbsd dragonfly
+// +build linux darwin freebsd openbsd netbsd dragonfly solaris
 
 // Copyright 2013-2015 Bowery, Inc.
 

--- a/vendor/github.com/Bowery/prompt/term_solaris.go
+++ b/vendor/github.com/Bowery/prompt/term_solaris.go
@@ -1,0 +1,7 @@
+package prompt
+
+import "golang.org/x/sys/unix"
+
+const tcgets = unix.TCGETS
+const tcsetsf = unix.TCSETSF
+const tcsets = unix.TCSETS

--- a/vendor/github.com/Bowery/prompt/term_unix.go
+++ b/vendor/github.com/Bowery/prompt/term_unix.go
@@ -1,4 +1,4 @@
-// +build linux darwin freebsd openbsd netbsd dragonfly
+// +build linux darwin freebsd openbsd netbsd dragonfly solaris
 
 // Copyright 2013-2015 Bowery, Inc.
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "rcwA7Jmo3eZ4bEQb8mTI78haZfc=",
+			"checksumSHA1": "mBpqi6N3JJTdSpq71vI8vwuffl8=",
 			"path": "github.com/Bowery/prompt",
-			"revision": "d43c2707a6c5a152a344c64bb4fed657e2908a81",
-			"revisionTime": "2016-08-08T16:52:56Z"
+			"revision": "2708577f3274d7884e1c737218c625f651ba14b3",
+			"revisionTime": "2017-02-08T14:51:51Z"
 		},
 		{
 			"checksumSHA1": "6VGFARaK8zd23IAiDf7a+gglC8k=",


### PR DESCRIPTION
When trying to fetch a revision from a private bitbucket repository, govendor fails when trying to access the bitbucket api. The request needs to be authenticated with basic auth. ( https://confluence.atlassian.com/bitbucket/use-the-bitbucket-cloud-rest-apis-222724129.html ) 

I extended the error to contain the original message and extended the interal api with non-breaking-changes so we can authenticate requests. 